### PR TITLE
Add action to require that every PR changes a specified file

### DIFF
--- a/require-file-change/README.md
+++ b/require-file-change/README.md
@@ -1,0 +1,35 @@
+# require-file-change GitHub Action
+
+This is a GitHub Action that fails unless a PR has changed a specific file or (optionally) has a specific label.
+
+## Usage
+
+For example, to check that PRs either update `docs/release-notes.md` or set the `skip-notes` label:
+
+```yaml
+name: Release notes
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  require-notes:
+    name: Require release note
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require release-notes.md update
+        uses: coreos/actions-lib/require-file-change@main
+        with:
+          # Optional: if the PR has this label, skip the check
+          override-label: skip-notes
+          # Required: path to the file we're interested in
+          path: docs/release-notes.md
+          # Optional: use this Personal Access Token to query GitHub
+          # Default: ${{ github.token }}
+          token: ${{ github.token }}
+```

--- a/require-file-change/action.yml
+++ b/require-file-change/action.yml
@@ -1,0 +1,40 @@
+name: Require file change
+description: Fail unless a specified file is changed by a PR
+
+inputs:
+  override-label:
+    description: Skip check if the PR has this label
+    required: false
+  path:
+    description: Path to file
+    required: true
+  token:
+    description: Personal access token
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Check for ${{ inputs.path }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -n "${{ inputs.override-label }}" ]; then
+            label=$(echo '${{ toJSON(github.event.pull_request.labels) }}' |
+                    jq '.[] | select(.name == "${{ inputs.override-label }}")')
+            if [ -n "${label}" ]; then
+                echo "PR has ${{ inputs.override-label }} label; skipping"
+                exit 0
+            fi
+        fi
+        diffinfo=$(curl --no-progress-meter \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token ${{ inputs.token || github.token }}" \
+            "https://api.github.com/repos/${{ github.repository }}/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" |
+            jq '.files[] | select(.filename == "${{ inputs.path }}")')
+        if [ -z "${diffinfo}" ]; then
+            echo "Found no changes to ${{ inputs.path }}."
+            echo "To ignore, add ${{ inputs.override-label }} label to PR."
+            exit 1
+        fi
+        echo "Found change to ${{ inputs.path }}."


### PR DESCRIPTION
Optionally, allow overriding the check by setting a specified label on the PR.

This is useful for ensuring that PRs update the release notes.