### PR TITLE
require-file-change: don't trust label list in triggering event

### DIFF
--- a/require-file-change/action.yml
+++ b/require-file-change/action.yml
@@ -20,8 +20,13 @@ runs:
       run: |
         set -euo pipefail
         if [ -n "${{ inputs.override-label }}" ]; then
-            label=$(echo '${{ toJSON(github.event.pull_request.labels) }}' |
-                    jq '.[] | select(.name == "${{ inputs.override-label }}")')
+            # Don't trust the label list in the event metadata, since runs
+            # can be scheduled out of order and the list might be stale.
+            label=$(curl --no-progress-meter \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: token ${{ inputs.token || github.token }}" \
+                "${{ github.event.pull_request.url }}" |
+                jq '.labels[] | select(.name == "${{ inputs.override-label }}")')
             if [ -n "${label}" ]; then
                 echo "PR has ${{ inputs.override-label }} label; skipping"
                 exit 0


### PR DESCRIPTION
If a PR is created with the override label already applied, GitHub spawns two job runs, one for the creation and one for the labeling, and those runs can be scheduled out of order.  The labels in the event correspond to the state at the time the job was queued, so if we trust them, we can send a stale job result to the PR.  Read the current labels from the API instead.