### PR TITLE
build-container: support overriding registry tags

### DIFF
--- a/build-container/README.md
+++ b/build-container/README.md
@@ -2,7 +2,7 @@
 
 This is a GitHub Action for building and optionally pushing a multi-arch container image using Podman.
 
-If `push` is specified, and the action is not running from a PR, the container image is pushed to a registry.  The image is tagged with the name of the Git branch or tag.  If the branch name matches the `latest-branch` parameter (`main` by default), the container image is also tagged with `latest`.
+If `push` is specified, and the action is not running from a PR, the container image is pushed to a registry.  The image is tagged with the name of the Git branch or tag.  If the branch name matches the `latest-branch` parameter (`main` by default), the container image is also tagged with `latest`.  If the `tags` parameter is specified, PR detection is skipped and the container image is pushed exclusively to the specified tags.
 
 ## Usage
 
@@ -35,4 +35,8 @@ If `push` is specified, and the action is not running from a PR, the container i
     # Optional space-separated list of repositories to push to
     # (ignored for PR builds)
     push: ''
+
+    # Optional space-separated list of tags to push to
+    # (overrides PR detection)
+    tags: ''
 ```

--- a/build-container/action.yml
+++ b/build-container/action.yml
@@ -29,13 +29,20 @@ inputs:
     description: Optional space-separated list of repositories to push to (ignored for PR builds)
     default:
     required: false
+  tags:
+    description: Optional space-separated list of tags to push to (overrides PR detection)
+    default:
+    required: false
 runs:
   using: composite
   steps:
     - name: Compute settings
       shell: bash
       run: |
-        if [[ "${GITHUB_REF}" == refs/heads/* ]]; then
+        if [[ -n "${{ inputs.tags }}" ]]; then
+            tags="${{ inputs.tags }}"
+            arches="${{ inputs.arches }}"
+        elif [[ "${GITHUB_REF}" == refs/heads/* ]]; then
             tags="${GITHUB_REF#refs/heads/}"
             if [[ "$tags" == "${{ inputs.latest-branch }}" ]]; then
                 tags="$tags latest"


### PR DESCRIPTION
Workflows might want to use our build and push logic but select their own destination tags.  Provide an option to do that.