### PR TITLE
workflows: update actions to current major versions

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Install dependencies
         run: dnf install -y git-core
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run self-test
         run: check-diff/check-diff.py --selftest .

--- a/check-diff/README.md
+++ b/check-diff/README.md
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # ensure we also fetch the base commit
           fetch-depth: 0


### PR DESCRIPTION
Fixes [deprecation warnings](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) for Node.js 12.