### PR TITLE
Add python installation to the Dockerfile

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -15,7 +15,7 @@ jobs:
     container: registry.fedoraproject.org/fedora:latest
     steps:
       - name: Install dependencies
-        run: dnf install -y git-core
+        run: dnf install -y git-core python
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Run self-test

--- a/check-diff/Dockerfile
+++ b/check-diff/Dockerfile
@@ -1,3 +1,4 @@
 FROM registry.fedoraproject.org/fedora:latest
+RUN dnf install -y python
 COPY check-diff.py /usr/bin/check-diff
 ENTRYPOINT ["/usr/bin/check-diff"]


### PR DESCRIPTION
As the latest Fedora version does not have the python pkg installed,
the installation of python pkg step is added in the Dockerfile

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1831